### PR TITLE
classwork7.js

### DIFF
--- a/classwork7.js
+++ b/classwork7.js
@@ -1,0 +1,59 @@
+//SingleFieldIndex
+db.student.createIndex({"class_id":551},
+{
+"createdCollectionAutomatically" :
+false,
+"numIndexesBefore": 1,
+"numIndexsAfter": 2,
+"ok" : 1
+})
+
+< class_id_551
+> db.student.getIndexes()
+
+
+//CompoundIndex
+  db.student.createIndex({student_id: 777777, student_id: 223344},
+{
+			"createdCollectionAutomatically": false,
+			"numIdexesBefore":1,
+			"numIndexesAfter":2,
+			"ok":1
+})
+
+< student_id_223344
+> db.student.getIndexes()
+
+
+//MultikeyIndex
+db.student.createIndex({student:1},
+{
+			"createdCollectionAutomatically": false,
+			"numIdexesBefore":1,
+			"numIndexesAfter":2,
+			"ok":1
+})
+
+< student_1
+> db.student.getIndexes()
+
+
+//GeoSpatial
+db.student.createIndex({"score":"2dsphere"},
+{
+			"createdCollectionAutomatically": false,
+			"numIdexesBefore":1,
+			"numIndexesAfter":2,
+			"ok":1
+})
+
+< score_2dsphere
+> db.student.getIndexes()
+
+//Dropindex
+db.student.dropIndex({key: {student_id:551}},
+{
+			"createdCollectionAutomatically": false,
+			"numIdexesBefore":1,
+			"numIndexesAfter":2,
+			"ok":1


### PR DESCRIPTION
Indexing:
Indexing in MongoDB is a crucial aspect of database optimization, as it helps improve query performance by allowing the database engine to locate and retrieve documents more efficiently.
Here are the basic steps to create and use indexes in MongoDB:
![1](https://github.com/Saurabhcfc09/Adv.DbmsDesign/assets/157640196/fe2e705d-ff36-4e1e-82db-f61864e5d2c9)

Single Field Index: A single field index in MongoDB is an index that is created on a single field within a document in a MongoDB collection.
311016384-6a8d2b2e-c25a-4e1b-8d0b-b94e94cf743c
![2](https://github.com/Saurabhcfc09/Adv.DbmsDesign/assets/157640196/b857b33c-92cd-4f66-bd9c-3e4b36275fe0)

Compound Index : A compound index in MongoDB is an index created on multiple fields within a document in a MongoDB collection. Unlike a single field index, which is created on a single field, a compound index involves multiple fields. This type of index can be beneficial when queries involve multiple criteria or when sorting and filtering are performed on multiple fields simultaneously.
Here's an example of creating a compound index in MongoDB:
311017098-cfb804d3-cf80-46ee-bfbe-70844c3e5570
3.Multi-Key Index: A multi-key index in MongoDB is an index that is created on an array field, where each element of the array is indexed separately. This allows MongoDB to efficiently index and query documents based on the values within arrays. Multi-key indexes are particularly useful when dealing with fields that contain arrays of values.
Here's an example of creating a multi-key index in MongoDB:
311018885-dea9cfa2-2966-4b00-b92a-5722fc037dd9
![3](https://github.com/Saurabhcfc09/Adv.DbmsDesign/assets/157640196/f232231e-6bde-4474-afd0-0f6cc4785385)

Geospatial Indexes: Geospatial indexes in MongoDB are specialized indexes that support efficient queries involving geographical data. MongoDB provides two types of geospatial indexes: 2d indexes and 2dsphere indexes. These indexes are designed to optimize the retrieval of documents based on their spatial coordinates, making it easier to perform location-based queries.
311019309-6663bee0-d8e7-4fe6-b4e5-6e8804c0fa1f
Dropping an Index: Dropping an index in MongoDB is a straightforward process. You can use the dropIndex() method to remove an existing index from a collection.
Here's the basic syntax:
db.collection.dropIndex("index_name")
311019855-ea346b21-0c67-4ae5-82db-e2974d5736e9
![4](https://github.com/Saurabhcfc09/Adv.DbmsDesign/assets/157640196/df7c090c-a192-4cae-8606-9e5ef570b585)
